### PR TITLE
Reorder application of colors in RB_Jacobi

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,6 @@ some effort to code up your own interpolation matrix.)
 
 Some potential to-do's:
 * Implement a 2D/3D version.
-* Create a multi-equation version (i.e., multiple unknowns per spatial node)
+* Create a multi-equation (block) version (i.e., multiple unknowns per spatial node)
 * Make it easier to define custom restriction/interpolation operators
 * More complex boundary conditions

--- a/py_simplemg/smoothers.py
+++ b/py_simplemg/smoothers.py
@@ -24,6 +24,7 @@ def blk_jacobi(A, x, b, smooth_opts):
   else:
     num_color = 1
 
+  #Iterate backwards over the number of colors:
   color = num_color
   while(color > 1):
     color -= 1
@@ -44,5 +45,4 @@ def blk_jacobi(A, x, b, smooth_opts):
 
     x = x+tmpdiag.dot(b - A.dot(x))
 
-    color = color + 1
   return smooth_opts.omega*x + (1-smooth_opts.omega)*x0

--- a/py_simplemg/smoothers.py
+++ b/py_simplemg/smoothers.py
@@ -15,15 +15,19 @@ class SmootherOptions(object):
 
 def blk_jacobi(A, x, b, smooth_opts):
   """ Performs one block Jacobi iteration.  Red-black ordering can be toggled
-      on/off. """
+      on/off.  The "block" aspect has not been implemented yet, so it's
+      really just red/black Jacobi.
+  """
   x0 = x
   if smooth_opts.redblack:
     num_color = 2
   else:
     num_color = 1
 
-  color = 0
-  while(color < num_color):
+  color = num_color
+  while(color > 1):
+    color -= 1
+
     if smooth_opts.sparse:
       tmpdiag = A.diagonal()
     else:


### PR DESCRIPTION
This order of coloring synchronizes well with the current default
interpolation for 1D problems.  In the current interpolation scheme, the even-
numbered points map injectively to the coarse-grid points and, in principle,
should be more accurate than the adjacent odd-numbered points whose values are
updated via interpolation.  Thus, in the red-black jacobi iteration, it makes
sense to update the odd-numbered points first, since the update of those values
depends entirely on the error in the even-numbered points.

I also added a disclaimer that the "block" aspect of the block Jacobi
has not been implemented yet.